### PR TITLE
updated certbot version as a new image cannot be currently built

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --update python python-dev py-pip \
     augeas-dev openssl-dev libffi-dev ca-certificates dialog \
     && rm -rf /var/cache/apk/*
 
-ENV CERTBOT_VERSION 0.8.1
+ENV CERTBOT_VERSION 0.30.0
 
 RUN pip install -U certbot==$CERTBOT_VERSION
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ $ docker run --rm -it \
     --net=<your-network-name> \
     adop/certbot:VERSION <command>
 ```
-Where ```command``` is ```certbot``` command.
+Where ```command``` is certbot's ```certonly``` as the cerbot command is the Docker image entrypoint.
 
 Example:
 ```
-certbot certonly --standalone -d ${DOMAIN_NAME} --text --register-unsafely-without-email --agree-tos"
+"certonly --standalone -d ${DOMAIN_NAME} --text --register-unsafely-without-email --agree-tos"
 ```
 
 after the above, the Certbot will request SSL certificates for the ```$DOMAIN_NAME``` and save it to ```<store-path>```.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Supported tags and respective Dockerfile links
 
-- [`0.8.1` (*0.8.1/Dockerfile*)](https://github.com/Accenture/certbot/blob/master/Dockerfile)
+- [`0.30.0` (*0.30.0/Dockerfile*)](https://github.com/Accenture/certbot/blob/master/Dockerfile)
 
 # What is Certbot?
 


### PR DESCRIPTION
Updated certbot version as a new image cannot be built.

Certbot version update also fixes:

- CVE-2017-7614
- CVE-2017-7614
- CVE-2017-7555
- CVE-2017-7555
- CVE-2017-16931
- CVE-2017-16931
- CVE-2017-10989
- CVE-2017-10685
- CVE-2017-10685
- CVE-2017-10685
- CVE-2017-10684
- CVE-2017-10684
- CVE-2017-10684
- CVE-2017-1000158
- CVE-2017-1000158
- CVE-2016-9843
- CVE-2016-9843
- CVE-2016-9841
- CVE-2016-9841
- CVE-2016-8859
- CVE-2016-8859
- CVE-2016-8859
- CVE-2016-6304
- CVE-2016-6304
- CVE-2016-6304
- CVE-2016-6301
- CVE-2016-5300